### PR TITLE
feat: support sqs options object as alternative to MiniSQSClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,38 @@ Options are an array of objects with the following properties (one for each queu
 | parallelExecution     | boolean                             | Enable parallel execution of message handlers.                                                                                                                                                                                                                                                                        |
 | credentials           | {accessKeyId, secretAccessKey}      | Explicit AWS credentials (alternative to environment configuration).                                                                                                                                                                                                                                                  |
 | events                | object                              | Events functions for the consumer (detail in next table).                                                                                                                                                                                                                                                             |
-| sqs                   | MiniSQSClient                       | Initialized [@fgiova/mini-sqs-client](https://www.npmjs.com/package/@fgiova/mini-sqs-client) instance (useful for testing sessions).                                                                                                                                                                                  |
+| sqs                   | MiniSQSClient \| SQSOptions          | Either an initialized [@fgiova/mini-sqs-client](https://www.npmjs.com/package/@fgiova/mini-sqs-client) instance (useful for testing sessions) or an options object used to build the client (see below).                                                                                                              |
 
 \* required
+
+### sqs options object
+
+Instead of passing a pre-built `MiniSQSClient`, you can pass an options object so the plugin builds the client for you:
+
+| Option        | Type                            | Description                                                                                  |
+|---------------|---------------------------------|----------------------------------------------------------------------------------------------|
+| endpoint      | string                          | Custom SQS endpoint (e.g. a local LocalStack/ElasticMQ instance).                            |
+| undiciOptions | Pool.Options                    | [undici](https://undici.nodejs.org/#/docs/api/Pool) `Pool` options for the underlying HTTP client. |
+| credentials   | {accessKeyId, secretAccessKey}  | Explicit AWS credentials. The top-level `credentials` option takes precedence over this one. |
+
+```js
+app.register(sqsConsumer, [
+    {
+        arn: "arn:aws:sqs:eu-central-1:000000000000:MyQueue",
+        sqs: {
+            endpoint: "http://localhost:4566",
+            undiciOptions: { connections: 1 },
+            credentials: {
+                accessKeyId: "AWS_ACCESS_KEY_ID",
+                secretAccessKey: "AWS_SECRET_ACCESS_KEY"
+            }
+        },
+        handlerFunction: async (message, fastify) => {
+            return true;
+        }
+    }
+]);
+```
 
 ## Decorator
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { Message, MiniSQSClient } from "@fgiova/mini-sqs-client";
+import { type Message, MiniSQSClient } from "@fgiova/mini-sqs-client";
 import { type HooksOptions, SQSConsumer } from "@fgiova/sqs-consumer";
 // @ts-expect-error
 import { Unpromise } from "@watchable/unpromise";
 import type { FastifyInstance } from "fastify";
 import fp from "fastify-plugin";
+import type { Pool } from "undici";
 
 declare module "fastify" {
 	interface FastifyInstance {
@@ -29,13 +30,27 @@ function createConsumer(
 	messageAttributeNames: string[] = [],
 	parallelExecution?: boolean,
 	hooks?: HooksOptions,
-	sqs?: MiniSQSClient,
+	sqs?:
+		| MiniSQSClient
+		| {
+				endpoint?: string;
+				undiciOptions?: Pool.Options;
+				credentials?: {
+					accessKeyId: string;
+					secretAccessKey: string;
+				};
+		  },
 	credentials?: {
 		accessKeyId: string;
 		secretAccessKey: string;
 	},
 ) {
 	const meta = { pendingMessages: 0 };
+	credentials =
+		credentials ??
+		(typeof sqs === "object" && !(sqs instanceof MiniSQSClient)
+			? sqs.credentials
+			: undefined);
 	return {
 		consumer: new SQSConsumer({
 			queueARN: queueArn,
@@ -53,7 +68,15 @@ function createConsumer(
 			},
 			hooks,
 			clientOptions: {
-				sqsClient: sqs,
+				sqsClient: sqs instanceof MiniSQSClient ? sqs : undefined,
+				endpoint:
+					typeof sqs === "object" && !(sqs instanceof MiniSQSClient)
+						? sqs.endpoint
+						: undefined,
+				undiciOptions:
+					typeof sqs === "object" && !(sqs instanceof MiniSQSClient)
+						? sqs.undiciOptions
+						: undefined,
 				/* c8 ignore next 1 */
 				signer: credentials ? { credentials } : undefined,
 			},
@@ -105,7 +128,16 @@ function sqsConsumerPlugin(
 		attributeNames?: string[];
 		events?: HooksOptions;
 		parallelExecution?: boolean;
-		sqs?: MiniSQSClient;
+		sqs?:
+			| MiniSQSClient
+			| {
+					endpoint?: string;
+					undiciOptions?: Pool.Options;
+					credentials?: {
+						accessKeyId: string;
+						secretAccessKey: string;
+					};
+			  };
 	}[],
 	done: (err?: Error) => void,
 ) {

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -38,7 +38,7 @@ test("sqs", async (t) => {
 	t.beforeEach(async (t) => {
 		await sqsPurge(queueUrl);
 		const app = Fastify({
-			logger: true,
+			logger: false,
 		});
 		t.context = {
 			app,
@@ -417,6 +417,97 @@ test("sqs", async (t) => {
 				sqsClient,
 			);
 			await t.resolves(messagePromise);
+		},
+	);
+
+	await t.test(
+		"plugin process success message with sqs options object",
+		async (t) => {
+			const { app } = t.context as { app: FastifyInstance };
+			const message = new Promise((resolve, _reject) => {
+				app.register(sqsPlugin, [
+					{
+						arn: queueArn,
+						sqs: {
+							endpoint: process.env.LOCALSTACK_ENDPOINT,
+							undiciOptions: { connections: 1 },
+							credentials: {
+								accessKeyId: "AWS_ACCESS_KEY_ID",
+								secretAccessKey: "AWS_SECRET_ACCESS_KEY",
+							},
+						},
+						waitTimeSeconds: 1,
+						timeout: 10_000,
+						handlerFunction: async (
+							message: Message,
+							_fastify: FastifyInstance,
+						) => {
+							resolve(message.Body);
+						},
+					},
+				]);
+			});
+			await app.ready();
+			await setTimeout(1000);
+			await sendSQS(
+				queueUrl,
+				{
+					message: "test-options",
+				},
+				sqsClient,
+			);
+
+			await t.resolveMatch(
+				message,
+				JSON.stringify({
+					message: "test-options",
+				}),
+			);
+		},
+	);
+
+	await t.test(
+		"plugin process success message with sqs options object and top-level credentials",
+		async (t) => {
+			const { app } = t.context as { app: FastifyInstance };
+			const message = new Promise((resolve, _reject) => {
+				app.register(sqsPlugin, [
+					{
+						arn: queueArn,
+						sqs: {
+							endpoint: process.env.LOCALSTACK_ENDPOINT,
+						},
+						credentials: {
+							accessKeyId: "AWS_ACCESS_KEY_ID",
+							secretAccessKey: "AWS_SECRET_ACCESS_KEY",
+						},
+						waitTimeSeconds: 1,
+						timeout: 10_000,
+						handlerFunction: async (
+							message: Message,
+							_fastify: FastifyInstance,
+						) => {
+							resolve(message.Body);
+						},
+					},
+				]);
+			});
+			await app.ready();
+			await setTimeout(1000);
+			await sendSQS(
+				queueUrl,
+				{
+					message: "test-options-credentials",
+				},
+				sqsClient,
+			);
+
+			await t.resolveMatch(
+				message,
+				JSON.stringify({
+					message: "test-options-credentials",
+				}),
+			);
 		},
 	);
 


### PR DESCRIPTION
This pull request enhances the flexibility of the SQS consumer plugin by allowing users to provide either an initialized `MiniSQSClient` instance or an options object for SQS client configuration. This makes it easier to configure the plugin for different environments, such as local development or testing. The documentation and tests have been updated to reflect and verify this new capability.

**SQS client configuration improvements:**

* The `sqs` option in both the plugin and consumer creation now accepts either a `MiniSQSClient` instance or an options object (`endpoint`, `undiciOptions`, and `credentials`). This enables on-the-fly client construction without requiring a pre-built client. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L32-R53) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L56-R79) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L108-R140)
* If both top-level `credentials` and `sqs.credentials` are provided, the top-level `credentials` take precedence, ensuring clear and predictable credential resolution.

**Documentation updates:**

* The `README.md` has been updated to document the new SQS options object, including a usage example and detailed descriptions of each option.

**Testing enhancements:**

* Added new unit tests to verify that the plugin works correctly when using the SQS options object, both with and without top-level credentials.

**Minor improvements:**

* Disabled logging in unit tests to reduce noise.